### PR TITLE
change line 374 to make table_clean function change str1

### DIFF
--- a/MDA Extractor.py
+++ b/MDA Extractor.py
@@ -371,7 +371,7 @@ with open(download, 'r') as txtfile:
         
 ############# Remove Teble Sections #########################
 
-        output1=table_clean('<table','</table>',str1)
+        str1=table_clean('<table','</table>',str1)
         
 ############# Remove Newlines and Carriage Returns #########################
 


### PR DESCRIPTION
Dear Anton Podobytko, I have been learning your code and thank you very much for your sharing.
In line 374 of MDA extractor, output1 is created but never used. I was wondering whether "output1" should be replaced by "str1" as the function returns "current" instead of changing "str1" directly. I checked the length of "str1" and "output1", clearly they are not the same.
Or is it because the table cleaning does not affect our information extraction part?